### PR TITLE
test(pytest): register custom markers (smoke, regression)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    smoke: critical tests that validate main application flow
+    regression: full regression test suite


### PR DESCRIPTION
## Description

Registers custom pytest markers to avoid PytestUnknownMarkWarning and standardize test categorization.

## What was implemented

- Added `pytest.ini`
- Registered custom markers:
  - `smoke`
  - `regression`

## Why

Without marker registration, pytest raises warnings for unknown markers.

This change improves:
- Test organization
- Pipeline filtering capability
- CI reliability
- Codebase professionalism

## Impact

Enables execution filtering such as:

pytest -m smoke
pytest -m regression
pytest -m "not smoke"
